### PR TITLE
Correct indentation for rule-loop

### DIFF
--- a/Chapter20/listing20-6.py
+++ b/Chapter20/listing20-6.py
@@ -23,11 +23,11 @@ class Parser:
         for block in blocks(file):
             for filter in self.filters:
                 block = filter(block, self.handler)
-                for rule in self.rules:
-                    if rule.condition(block):
-                        last = rule.action(block,
-                               self.handler)
-                        if last: break
+            for rule in self.rules:
+                if rule.condition(block):
+                    last = rule.action(block,
+                           self.handler)
+                    if last: break
         self.handler.end('document')
 
 class BasicTextParser(Parser):


### PR DESCRIPTION
All rules should not be applied for each filter. Filters and rules should be applied independent of each other.